### PR TITLE
change the convexity check

### DIFF
--- a/src/GridElements.cpp
+++ b/src/GridElements.cpp
@@ -1727,7 +1727,7 @@ void Mesh::Validate() const {
 
 #endif
 */
-			if (dDot > 0.0) {
+			if (dDot > 1.e-15) {
 				printf("\nError detected (orientation):\n");
 				printf("  Face %i, Edge %i, Orientation %1.5e\n",
 					i, j, dDot);


### PR DESCRIPTION
0. is too strict for MOAB
until we fix intersection, we need this workaround

ne120 meshes do not work